### PR TITLE
Replace deprecated ast.Num with ast.Constant

### DIFF
--- a/ihatemoney/utils.py
+++ b/ihatemoney/utils.py
@@ -270,8 +270,8 @@ def eval_arithmetic_expression(expr):
             ast.USub: operator.neg,
         }
 
-        if isinstance(node, ast.Num):  # <number>
-            return node.n
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):  # <number>
+            return node.value
         elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
             return operators[type(node.op)](_eval(node.left), _eval(node.right))
         elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1


### PR DESCRIPTION
## Summary
- `ast.Num` / `node.n` have been deprecated since Python 3.8 in favor of `ast.Constant` / `node.value`. Updated `eval_arithmetic_expression` in `ihatemoney/utils.py` accordingly.
- Added `isinstance(node.value, (int, float))` to preserve the numbers-only behavior `ast.Num` provided, so non-numeric constants (e.g. strings) continue to be rejected.

## Test plan
- [ ] `1+2` → `3`
- [ ] `3.5 * 2` → `7.0`
- [ ] `-4 + 10/2` → `1.0`
- [ ] String literal (`"hi"`) → raises `ValueError`
- [ ] Division by zero (`1/0`) → raises `ValueError`
- [ ] Existing test suite passes