### PR TITLE
Raise ValueError for missing exchange rates

### DIFF
--- a/ihatemoney/currency_convertor.py
+++ b/ihatemoney/currency_convertor.py
@@ -221,6 +221,10 @@ class CurrencyConverter(object, metaclass=Singleton):
             return amount
 
         rates = self.get_rates()
+        if source_currency not in rates or dest_currency not in rates:
+            raise ValueError(
+                f"Exchange rate unavailable for {source_currency}->{dest_currency}"
+            )
         source_rate = rates[source_currency]
         dest_rate = rates[dest_currency]
         new_amount = (float(amount) / source_rate) * dest_rate


### PR DESCRIPTION
## Summary
- When the upstream `exchangerate.host` API call fails, `CurrencyConverter.get_rates()` falls back to `{"XXX": 1.0}`. The downstream `exchange_currency(...)` then did `rates[source_currency]` / `rates[dest_currency]` unconditionally, so any conversion between real currencies (e.g. bill creation/edit in EUR→USD) crashed with a bare `KeyError` during a transient API outage.
- Add an explicit check: if either currency is missing from the rates dict, raise a `ValueError` naming the offending pair so callers can detect and handle the missing-rate case rather than seeing a 500 from a `KeyError` deep in the stack.

## Test plan
- [ ] Happy path: `exchange_currency(100, "USD", "EUR")` still returns the converted amount.
- [ ] Same-currency / `XXX` short-circuit (returned `amount` before reaching `get_rates()`) is unchanged.
- [ ] With `get_rates()` mocked to return `{"XXX": 1.0}`, `exchange_currency(100, "EUR", "USD")` raises `ValueError` (not `KeyError`).
- [ ] Existing test suite passes.